### PR TITLE
Cabs naming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,6 @@ services:
       - ies
     tty: true
     volumes:
-      - "${SEABASS_MOUNT_PATH}:/mnt/"
+      - "${SEABASS_MOUNT_PATH}:/home/"
     entrypoint: /wait-for-it.sh ies:1247
     command: -- /comstart.sh

--- a/rescnamer.pl
+++ b/rescnamer.pl
@@ -1,6 +1,21 @@
 use strict;
 use warnings;
 
+
+my $RESOURCES = $ARGV[0];
+
+#first we wait for the resource servers to get ready. 
+my $upcount = 0;
+
+while ($upcount - 1 < $RESOURCES  ) {
+  print "waiting for resources to get ready...";
+  my $rstring = `docker exec -i icom ilsresc`;
+  my @uparray = split("\n",$rstring);
+  $upcount = scalar @uparray;
+}
+
+
+
 # open the csv
 open (IN, "psparsed.csv");
 

--- a/seabass.sh
+++ b/seabass.sh
@@ -31,7 +31,7 @@ fi
 
 # rename resources
 docker ps --format "{{.Image}},{{.ID}},{{.Names}}" > psparsed.csv
-perl rescnamer.pl
+perl rescnamer.pl $RESOURCES
 rm psparsed.csv
 
 # drop into interactive session


### PR DESCRIPTION
fixed the issue where the rescnamer.pl attempts to change the resource names before they are attached, causing error. 

changed mountpoint from /mnt/ to /home/
